### PR TITLE
Loosen dependency constraints: use lts-13.17 versions

### DIFF
--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -24,20 +24,20 @@ library
                        Data.Generic.HKD.Types
   -- other-modules:
   -- other-extensions:
-  build-depends:       base ^>=4.12.0.0
-                     , barbies ^>=1.1.0.0
-                     , generic-lens ^>=1.1.0.0
-                     , QuickCheck ^>=2.13.0
+  build-depends:       base >=4.12
+                     , barbies >=1.1.0
+                     , generic-lens >=1.1.0
+                     , QuickCheck >=2.12.6
   hs-source-dirs:      src
   default-language:    Haskell2010
 
 test-suite test
   build-depends:       base
-                     , doctest ^>=0.16.0
+                     , doctest >=0.16.0
                      , higgledy
-                     , hspec ^>=2.7.0
-                     , lens ^>=4.17
-                     , QuickCheck
+                     , hspec >=2.6.1
+                     , lens >=4.17
+                     , QuickCheck >= 2.12.6
   main-is:             Main.hs
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test


### PR DESCRIPTION
I noticed the versions of all dependencies appear to be the most recent versions on hackage respectively while not actually _needing_ any of the dependencies to be as recent. I changed all dependencies to the versions used in Stackage lts-13.17 instead (https://www.stackage.org/lts-13.17/cabal.config).

Seems sensible to me but I don't pretend to be super knowledgeable with all these versioning shenanigans.

_PS: FWIW this now also builds fine with the `haskellPackages` from nixos 18.09_