### PR TITLE
Update for stackage nightly

### DIFF
--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -26,7 +26,7 @@ library
   build-depends:       base ^>= 4.12
                      , barbies ^>= 1.1.0
                      , generic-lens ^>= 1.1.0
-                     , QuickCheck ^>= 2.12.6
+                     , QuickCheck >= 2.12.6 && < 2.14
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -35,9 +35,9 @@ test-suite test
                      , barbies ^>= 1.1.0
                      , doctest ^>= 0.16.0
                      , higgledy
-                     , hspec ^>= 2.6.1
+                     , hspec >= 2.6.1 && < 2.8
                      , lens ^>= 4.17
-                     , QuickCheck ^>= 2.12.6
+                     , QuickCheck >= 2.12.6 && < 2.14
   main-is:             Main.hs
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test

--- a/src/Data/Generic/HKD.hs
+++ b/src/Data/Generic/HKD.hs
@@ -65,7 +65,7 @@ import qualified Data.Generics.Product as G
 -- >>> total & field @"oops" .~ pure ()
 -- ...
 -- ... error:
--- ... • The type HKD User Last does not contain a field named 'oops'.
+-- ... The type HKD User Last does not contain a field named 'oops'.
 -- ...
 field
   :: forall field f structure inner
@@ -91,8 +91,8 @@ field
 -- >>> deconstruct ("Hello", True) ^. position @4
 -- ...
 -- ... error:
--- ... • The type HKD
--- ...              ([Char], Bool) f does not contain a field at position 4
+-- ... The type HKD
+-- ... ([Char], Bool) f does not contain a field at position 4
 -- ...
 position
   :: forall index f structure inner

--- a/src/Data/Generic/HKD/Build.hs
+++ b/src/Data/Generic/HKD/Build.hs
@@ -75,14 +75,14 @@ instance (Generic shape, GFill f with '[] (Rep shape))
 --   = User { name :: String, age :: Int, likesDogs :: Bool }
 --   deriving Generic
 -- :}
--- 
+--
 -- >>> :{
 -- test :: _
 -- test = build @User
 -- :}
 -- ...
--- ... • Found type wildcard ‘_’
--- ...     standing for ‘f [Char] -> f Int -> f Bool -> HKD User f’
+-- ... Found type wildcard ...
+-- ... standing for ...f [Char] -> f Int -> f Bool -> HKD User f...
 -- ...
 --
 -- Once we call the 'build' function, and indicate the type we want to build,


### PR DESCRIPTION
I tried building higgledy 0.3 with stackage 2019-07-31 nightly and ran into version bound conflicts, so I relaxed the upper bounds in the cabal file. 
I've also modified the doctests to pass with the new ghc; there were trivial differences in the error messages. I've modified the expected output to be compatible with both versions.

E.g.
```
src/Data/Generic/HKD/Build.hs:79: failure in expression `:{ 
 test :: _                                                                               
 test = build @User                                            
:}'                                                                                      
expected: ...                                                                            
          ... • Found type wildcard ‘_’                                                  
          ...     standing for ‘f [Char] -> f Int -> f Bool -> HKD User f’
          ...                                                                            
 but got:                                                   
          <interactive>:68:10: error:                                                    
              * Found type wildcard `_'                           
                  standing for `f [Char] -> f Int -> f Bool -> HKD User f'                                                                                                                                                                    
                Where: `f' is a rigid type variable bound by        
                         the inferred type of                                            
                           test :: f [Char] -> f Int -> f Bool -> HKD User f   
                         at <interactive>:69:2-19                                                                                                                                                                                             
                To use the inferred type, enable PartialTypeSignatures    
              * In the type signature: test :: _
```
Note the `*` instead of `•` and different quotation marks 