### PR TITLE
Fixes for generic-lens 2.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,9 @@
+packages: .
+
+with-compiler: ghc-8.8.3
+
+source-repository-package
+  type: git
+  location: https://github.com/AlistairB/generic-lens.git
+  tag: e9fe04b049aa62c4489014537a4e2a0cf8644c79
+  subdir: generic-lens-core

--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -24,9 +24,10 @@ library
                        Data.Generic.HKD.Types
   -- other-modules:
   -- other-extensions:
-  build-depends:       base ^>= 4.12
-                     , barbies ^>= 1.1.0
-                     , generic-lens ^>= 1.1.0
+  build-depends:       base ^>= 4.13
+                     , barbies >= 1.1.0 && < 3
+                     , generic-lens ^>= 2.0
+                     , generic-lens-core ^>= 2.0
                      , QuickCheck >= 2.12.6 && < 2.14
                      , named ^>= 0.3.0.0
   hs-source-dirs:      src
@@ -34,11 +35,11 @@ library
 
 test-suite test
   build-depends:       base
-                     , barbies ^>= 1.1.0
+                     , barbies >= 1.1.0 && < 3
                      , doctest ^>= 0.16.0
                      , higgledy
                      , hspec >= 2.6.1 && < 2.8
-                     , lens ^>= 4.17
+                     , lens ^>= 4.19
                      , QuickCheck >= 2.12.6 && < 2.14
   main-is:             Main.hs
   type:                exitcode-stdio-1.0
@@ -47,8 +48,8 @@ test-suite test
 
 test-suite readme
   build-depends:       base
-                     , barbies ^>= 1.1.0
-                     , lens ^>= 4.17
+                     , barbies >= 1.1.3.0 && < 3
+                     , lens ^>= 4.19
                      , higgledy
                      , named ^>= 0.3.0.0
   main-is:             README.lhs

--- a/src/Data/Generic/HKD/Build.hs
+++ b/src/Data/Generic/HKD/Build.hs
@@ -25,7 +25,7 @@ module Data.Generic.HKD.Build
   ) where
 
 import Data.Kind (Type)
-import Data.GenericLens.Internal (HList (..))
+import Data.Generics.Product.Internal.HList (HList (..))
 import Data.Generic.HKD.Types (HKD (..), GHKD_)
 import GHC.Generics
 import Prelude hiding (uncurry)

--- a/src/Data/Generic/HKD/Named.hs
+++ b/src/Data/Generic/HKD/Named.hs
@@ -28,7 +28,7 @@ module Data.Generic.HKD.Named
 
 import Data.Functor.Contravariant (Contravariant (..))
 import Data.Generic.HKD.Types (HKD, HKD_)
-import Data.GenericLens.Internal (GUpcast (..))
+import Data.Generics.Product.Internal.Subtype (GUpcast (..))
 import Data.Kind (Type)
 import GHC.Generics
 import Named ((:!), NamedF (..))


### PR DESCRIPTION
#23

Also bump other dependencies.

This is mostly sketching something that builds. I have no idea if this is the right solution, or if my version range bumps make sense.

As noted in the issue, this depends on a fork of `generic-lens-core` that exposes `GUpcast` again.

EDIT: I updated to use barbies version 1 or 2. 2.0 deprecates a bunch of stuff. I tried to update to use the non-deprecated bits, but there have been a lot of changes to barbies. I think this needs to be done by someone who understands how higgedly works :sweat_smile: 