### PR TITLE
Support ghc >= 8.8

### DIFF
--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -24,8 +24,8 @@ library
                        Data.Generic.HKD.Types
   -- other-modules:
   -- other-extensions:
-  build-depends:       base ^>= 4.12
-                     , barbies ^>= 1.1.0
+  build-depends:       base >= 4.12 && < 5
+                     , barbies ^>= 2.0.0
                      , generic-lens ^>= 1.1.0
                      , QuickCheck >= 2.12.6 && < 2.14
                      , named ^>= 0.3.0.0
@@ -33,12 +33,12 @@ library
   default-language:    Haskell2010
 
 test-suite test
-  build-depends:       base
-                     , barbies ^>= 1.1.0
+  build-depends:       base >= 4.12 && < 5
+                     , barbies ^>= 2.0.0
                      , doctest ^>= 0.16.0
                      , higgledy
                      , hspec >= 2.6.1 && < 2.8
-                     , lens ^>= 4.17
+                     , lens >= 4.17 && < 5
                      , QuickCheck >= 2.12.6 && < 2.14
   main-is:             Main.hs
   type:                exitcode-stdio-1.0
@@ -46,9 +46,9 @@ test-suite test
   default-language:    Haskell2010
 
 test-suite readme
-  build-depends:       base
-                     , barbies ^>= 1.1.0
-                     , lens ^>= 4.17
+  build-depends:       base >= 4.12 && < 5
+                     , barbies ^>= 2.0.0
+                     , lens >= 4.17 && < 5
                      , higgledy
                      , named ^>= 0.3.0.0
   main-is:             README.lhs


### PR DESCRIPTION
Since `barbies` < v2 is incompatible with ghc 8.8, this PR adds support by using `barbies >= 2.0.0` instead of `1.1.0`. One caveat is that many things are now deprecated, so compilation gives out several warnings (`ProductB` renamed to `ApplicativeB`, `import Data.Barbie` is now `import Barbies` etc). I think it makes sense to change these but this might mean not being backwards compatible. Another downside of this change is that the new version of barbies has dropped support for ghc `8.0` and `8.2`, which means that if `higgledy` needs to support these as well we might need some clever thing with a compatibility layer or `if-else` s in the cabal file.

Also for some reason I couldn't get the `test` test-suite to pass, I am getting import errors when `Main.hs` tries to import something from `higgledy`, even without my changes. Maybe I am using some newer version of cabal? It would be useful to know if it's just me so that we can fix it for everyone.

Finally let me know if you'd like to have some CI that uses github actions to run the tests, I have a configuration already that can use a matrix of different ghc versions ([this](https://kodimensional.dev/github-actions), more or less) would be nice!