### PR TITLE
Update to generic lens 2.1.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,3 @@
 packages: .
 
 with-compiler: ghc-8.8.3
-
-source-repository-package
-  type: git
-  location: https://github.com/AlistairB/generic-lens.git
-  tag: e9fe04b049aa62c4489014537a4e2a0cf8644c79
-  subdir: generic-lens-core

--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -28,8 +28,8 @@ library
                    Data.Generic.HKD.Types
   build-depends: base >= 4.12 && < 5
                , barbies ^>= 2.0
-               , generic-lens ^>= 2.0
-               , generic-lens-core ^>= 2.0
+               , generic-lens >= 2.1 && < 3.0
+               , generic-lens-core >= 2.1 && < 3.0
                , QuickCheck >= 2.12.6 && < 2.14
                , named ^>= 0.3.0.0
   hs-source-dirs:      src


### PR DESCRIPTION
Closes #23

Generic lens 2.1.0.0 exposes `GUpcast` now :tada: 

I was a bit unsure on whether to do `^>= 2.1` vs `>= 2.1 && < 3.0` for generic lens. I figure 2.* versions are likely to work ok so went with the latter.