### PR TITLE
Fix GHC 9.2 build and add GitHub Actions support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+# Trigger the workflow on push or pull request, but only for the master branch
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    name: ghc ${{ matrix.ghc }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc:
+          - "8.10.7"
+          - "9.2.2"
+
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
+
+    - uses: haskell/actions/setup@v1
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - uses: actions/cache@v1
+      name: Cache ~/.cabal/store
+      with:
+        path: ~/.cabal/store
+        key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
+
+    - name: Build
+      run: |
+        cabal v2-update
+        cabal v2-build --enable-tests --enable-benchmarks
+
+    - name: Test
+      run: |
+        cabal v2-test --enable-tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Higgledy 📚
 
+[![GitHub CI](https://github.com/i-am-tom/higgledy/workflows/CI/badge.svg)](https://github.com/i-am-tom/higgledy/actions)
+
 Higher-kinded data via generics: all\* the benefits, but none\* of the
 boilerplate.
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,1 @@
 packages: .
-
-with-compiler: ghc-8.8.3

--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -37,8 +37,8 @@ library
 
 test-suite doctests
   build-depends: base
-               , base-compat ^>= 0.11
-               , doctest ^>= 0.17
+               , base-compat >= 0.11 && < 0.13
+               , doctest >= 0.17 && < 0.20
                , higgledy
                , lens
                , QuickCheck
@@ -54,7 +54,7 @@ test-suite test
                      , barbies
                      , higgledy
                      , hspec >= 2.6.1 && < 2.8
-                     , lens >= 4.17 && < 5
+                     , lens >= 4.17 && < 5.2
                      , QuickCheck
   main-is:             Main.hs
   type:                exitcode-stdio-1.0
@@ -64,7 +64,7 @@ test-suite test
 test-suite readme
   build-depends:       base
                      , barbies
-                     , lens >= 4.17 && < 5
+                     , lens >= 4.17 && < 5.2
                      , higgledy
                      , named ^>= 0.3.0.0
   main-is:             README.lhs

--- a/src/Data/Generic/HKD.hs
+++ b/src/Data/Generic/HKD.hs
@@ -88,11 +88,10 @@ field
 -- get some beautiful error messages when things go awry:
 --
 -- >>> import Data.Generic.HKD.Construction
--- >>> deconstruct ("Hello", True) ^. position @4
+-- >>> deconstruct ((), True) ^. position @4
 -- ...
 -- ... error:
--- ... The type HKD
--- ... ([Char], Bool) f does not contain a field at position 4
+-- ... The type HKD ((), Bool) f does not contain a field at position 4
 -- ...
 position
   :: forall index f structure inner

--- a/src/Data/Generic/HKD/Build.hs
+++ b/src/Data/Generic/HKD/Build.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE BlockArguments         #-}
 {-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}

--- a/src/Data/Generic/HKD/Types.hs
+++ b/src/Data/Generic/HKD/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE AllowAmbiguousTypes    #-}
 {-# LANGUAGE ConstraintKinds        #-}
 {-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE InstanceSigs           #-}


### PR DESCRIPTION
It turns out that GHC got a little cleverer at spotting a missing
`FlexibleContexts` extension. This adds fixes for that, widens bounds
as necessary, and adds a yml file to pull in GitHub Actions CI.