### PR TITLE
Support for GHC 9.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,14 @@ jobs:
       matrix:
         ghc:
           - "8.10.7"
-          - "9.2.2"
+          - "9.2.5"
+          - "9.4.4"
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -38,7 +38,7 @@ library
 test-suite doctests
   build-depends: base
                , base-compat >= 0.11 && < 0.13
-               , doctest >= 0.17 && < 0.20
+               , doctest >= 0.17 && < 0.22
                , higgledy
                , lens
                , QuickCheck
@@ -53,8 +53,8 @@ test-suite test
   build-depends:       base
                      , barbies
                      , higgledy
-                     , hspec >= 2.6.1 && < 2.8
-                     , lens >= 4.17 && < 5.2
+                     , hspec >= 2.6.1 && < 2.11
+                     , lens >= 4.17 && < 5.3
                      , QuickCheck
   main-is:             Main.hs
   type:                exitcode-stdio-1.0
@@ -64,7 +64,7 @@ test-suite test
 test-suite readme
   build-depends:       base
                      , barbies
-                     , lens >= 4.17 && < 5.2
+                     , lens >= 4.17 && < 5.3
                      , higgledy
                      , named ^>= 0.3.0.0
   main-is:             README.lhs


### PR DESCRIPTION
* Relax upper bounds on dependency versions
* Add 9.4.4 to test matrix