### PR TITLE
Release version 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Revision history for higgledy
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 4.2.1 -- 2023-03-04
 
-* First version. Released on an unsuspecting world.
+* Support for GHC 9.4

--- a/higgledy.cabal
+++ b/higgledy.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 build-type: Custom
 name: higgledy
-version: 0.4.1.1
+version: 0.4.2.1
 synopsis: Partial types as a type constructor.
 description: Use the generic representation of an ADT to get a higher-kinded data-style interface automatically.
 homepage: https://github.com/i-am-tom/higgledy


### PR DESCRIPTION
This PR bumps the library version and adds an entry to the changelog.

The latest version on hackage at the moment is `4.2.0`, which is why I've bumped to `4.2.1`.